### PR TITLE
Add holdBestAvailable example

### DIFF
--- a/seatsio-ios-example/ContentView.swift
+++ b/seatsio-ios-example/ContentView.swift
@@ -8,7 +8,13 @@
 import SwiftUI
 import Seatsio
 
+class ChartHolder: ObservableObject {
+    var chart: SeatingChart?
+}
+
 struct BasicWebView: UIViewRepresentable {
+
+    let chartHolder: ChartHolder
 
     func makeUIView(context: Context) -> SeatsioWebView {
         let config: SeatingChartConfig = SeatingChartConfig()
@@ -45,11 +51,18 @@ struct BasicWebView: UIViewRepresentable {
                 print(object, ticketType ?? "nil")
             })
             .selectedObjects([SelectedObject("VIP SEATS-A-7")])
-            .onChartRendered({ (chart) in
+            .onChartRendered({ [chartHolder] (chart) in
                 print("rendered")
+                chartHolder.chart = chart
                 chart.getReportBySelectability({ (report) in print(report)})
                 chart.changeConfig(ConfigChange(unavailableCategories: ["Balcony"]))
                 chart.isObjectInChannel("K-3", "NO_CHANNEL", { (result) in print("Is object in channel NO_CHANNEL? " + String(result)) })
+            })
+            .onBestAvailableHeld({ (objects, nextToEachOther) in
+                print("Best available held", objects, "nextToEachOther=\(String(describing: nextToEachOther))")
+            })
+            .onBestAvailableHoldFailed({ (message) in
+                print("Best available hold failed:", message)
             })
             .categoryFilter(CategoryFilter(enabled: true))
             .onHoldCallsInProgress({ () in
@@ -73,8 +86,16 @@ struct BasicWebView: UIViewRepresentable {
 }
 
 struct ContentView: View {
+    @StateObject private var chartHolder = ChartHolder()
+
     var body: some View {
-        BasicWebView()
+        VStack {
+            Button("Hold best available") {
+                chartHolder.chart?.holdBestAvailable(BestAvailableForHolding(number: 2))
+            }
+            .padding()
+            BasicWebView(chartHolder: chartHolder)
+        }
     }
 }
 

--- a/seatsio-ios-example/ContentView.swift
+++ b/seatsio-ios-example/ContentView.swift
@@ -58,12 +58,6 @@ struct BasicWebView: UIViewRepresentable {
                 chart.changeConfig(ConfigChange(unavailableCategories: ["Balcony"]))
                 chart.isObjectInChannel("K-3", "NO_CHANNEL", { (result) in print("Is object in channel NO_CHANNEL? " + String(result)) })
             })
-            .onBestAvailableHeld({ (objects, nextToEachOther) in
-                print("Best available held", objects, "nextToEachOther=\(String(describing: nextToEachOther))")
-            })
-            .onBestAvailableHoldFailed({ (message) in
-                print("Best available hold failed:", message)
-            })
             .categoryFilter(CategoryFilter(enabled: true))
             .onHoldCallsInProgress({ () in
                 print("hold calls in progress")
@@ -91,7 +85,9 @@ struct ContentView: View {
     var body: some View {
         VStack {
             Button("Hold best available") {
-                chartHolder.chart?.holdBestAvailable(BestAvailableForHolding(number: 2))
+                chartHolder.chart?.holdBestAvailable(BestAvailableForHolding(number: 2), { result in
+                    print("Best available held", result.objects.map { $0.label }, "nextToEachOther=\(String(describing: result.nextToEachOther))")
+                })
             }
             .padding()
             BasicWebView(chartHolder: chartHolder)


### PR DESCRIPTION
## Summary
- Adds a "Hold best available" button that calls `holdBestAvailable` with 2 seats
- Uses the callback-based API to log held objects (no `onBestAvailableHeld`/`onBestAvailableHoldFailed` config callbacks)
- Uses a `ChartHolder` to pass the chart reference from `onChartRendered` to the button

## Test plan
- [ ] Open the example app in Xcode, run on simulator
- [ ] Wait for chart to render, tap "Hold best available"
- [ ] Verify console logs show held objects
